### PR TITLE
Update artifact filtering regex

### DIFF
--- a/CI/scripts/version.ps1
+++ b/CI/scripts/version.ps1
@@ -202,7 +202,7 @@ function Confirm-ExtensionVersion
 	Write-Host ("Release extension version: {0}" -f $Release.version)
 	Write-Host ("Latest extension version: {0}" -f $Latest.version)
 
-	if ($Release.version -le $Latest.version)
+	if ([Version]$Release.version -le [Version]$Latest.version)
 	{
 		$ErrorMessage = "Extension version <$($Release.version)> cannot be released"
 

--- a/Tasks/TaggerV1/helpers/taskhelper.ts
+++ b/Tasks/TaggerV1/helpers/taskhelper.ts
@@ -119,7 +119,7 @@ export class TaskHelper implements ITaskHelper {
 
             const releaseArtifacts: string[] | undefined = artifactVariables.filter(
                 (i) => i.name.match("release.artifacts.*.type") && i.value === "Build")
-                    .map((i) => i.name.replace(".type", ""));
+                    .map((i) => i.name.substring(0, i.name.length - 5));
 
             for (const artifact of releaseArtifacts) {
 

--- a/Tasks/TaggerV1/helpers/taskhelper.ts
+++ b/Tasks/TaggerV1/helpers/taskhelper.ts
@@ -119,7 +119,7 @@ export class TaskHelper implements ITaskHelper {
 
             const releaseArtifacts: string[] | undefined = artifactVariables.filter(
                 (i) => i.name.match("release.artifacts.*.type") && i.value === "Build")
-                    .map((i) => i.name.substring(0, i.name.length - 5));
+                    .map((i) => i.name.replace("\.type$", ""));
 
             for (const artifact of releaseArtifacts) {
 

--- a/Tasks/TaggerV1/helpers/taskhelper.ts
+++ b/Tasks/TaggerV1/helpers/taskhelper.ts
@@ -119,7 +119,7 @@ export class TaskHelper implements ITaskHelper {
 
             const releaseArtifacts: string[] | undefined = artifactVariables.filter(
                 (i) => i.name.match("release.artifacts.*.type") && i.value === "Build")
-                    .map((i) => i.name.replace("\.type$", ""));
+                    .map((i) => i.name.replace(/\.type$/g, ""));
 
             for (const artifact of releaseArtifacts) {
 


### PR DESCRIPTION
Only remove ".type" from the end of an artifact name, not somewhere in the artifact name.

Otherwise tagging fails if an artifact name contains the text ".type"